### PR TITLE
Add new sg and player types

### DIFF
--- a/src/types/api/games/sg.types.ts
+++ b/src/types/api/games/sg.types.ts
@@ -15,6 +15,9 @@ interface Statistics_SG {
     cows: number;
     deathmatches: number;
     crates: number;
+    teleporters_used: number;
+    launchpads_used: number;
+    flares_used: number;
 }
 
 interface StatisticVariants {

--- a/src/types/api/metadata/player.types.ts
+++ b/src/types/api/metadata/player.types.ts
@@ -33,6 +33,7 @@ export interface PlayerMetadata {
 
     hat_count: number;
     hat_unlocked?: PlayerMetadata_Hat[];
+    equipped_hat?: PlayerMetadata_Hat;
 
     pets: string[];
     mounts: string[];


### PR DESCRIPTION
- Added 'teleporters_used', 'launchpads_used' and 'flares_used' to sg types.
- Added 'equipped_hat' to player types.