### PR TITLE
Add data for SkyWars Kits and SkyWars Classic

### DIFF
--- a/src/games/index.ts
+++ b/src/games/index.ts
@@ -14,6 +14,8 @@ import murder from "./murder";
 import party from "./party";
 import sg from "./sg";
 import sky from "./sky";
+import skykits from "./sky-kits";
+import skyclassic from "./sky-classic";
 import wars from "./wars";
 import bed from "./bed";
 import parkour from "./parkour";
@@ -29,6 +31,8 @@ export const Games = {
     [Game.JustBuild]: build,
     [Game.MurderMystery]: murder,
     [Game.Skywars]: sky,
+    [Game.SkywarsKits]: skykits,
+    [Game.SkywarsClassic]: skyclassic,
     [Game.SurvivalGames]: sg,
     [Game.TheBridge]: bridge,
     [Game.TreasureWars]: wars,

--- a/src/games/sky-classic.ts
+++ b/src/games/sky-classic.ts
@@ -1,0 +1,42 @@
+import { IMAGE_CDN } from ".";
+import { Game, Game_Variant_Queue_Type, Game_Variant_Type, Game_Data } from "../types/games.types";
+
+export default {
+    id: Game.SkywarsClassic,
+    short_name: "SKY-CLASSIC",
+    name: "SkyWars Classic",
+    discontinued: false,
+
+    description: "No lucky ores, loot chests to collect items.",
+    icon_url: IMAGE_CDN + "/icons/hub/games/sky-classic.png",
+
+    has_levels: true,
+    max_level: 100,
+    can_prestige: false,
+    max_prestige: null,
+    level_increment: 150,
+    level_cap: 52,
+
+    colours: ["#d6654d", "#cdcdcd", "#812b2c", "#f2e11f", "#50545a"],
+
+    modes: [
+        {
+            id: "sky-classic",
+            type: Game_Variant_Type.Regular,
+            name: "Classic Solos",
+            team_size: 1,
+            team_amount: 12,
+            limited: false,
+            queue_type: Game_Variant_Queue_Type.Default,
+        },
+        {
+            id: "sky-classic-squads",
+            type: Game_Variant_Type.Squads,
+            name: "Classic Squads",
+            team_size: 4,
+            team_amount: 4,
+            limited: false,
+            queue_type: Game_Variant_Queue_Type.Default,
+        },
+    ],
+} as Game_Data<Game.SkywarsClassic>;

--- a/src/games/sky-kits.ts
+++ b/src/games/sky-kits.ts
@@ -1,0 +1,43 @@
+import { IMAGE_CDN } from ".";
+import { Game, Game_Variant_Queue_Type, Game_Variant_Type, Game_Data } from "../types/games.types";
+
+// TODO: data for kits?
+export default {
+    id: Game.SkywarsKits,
+    short_name: "SKY-KITS",
+    name: "SkyWars Kits",
+    discontinued: false,
+
+    description: "Mine lucky ores to gain loot, then fight!",
+    icon_url: IMAGE_CDN + "/icons/hub/games/sky-kits.png",
+
+    has_levels: true,
+    max_level: 100,
+    can_prestige: false,
+    max_prestige: null,
+    level_increment: 150,
+    level_cap: 52,
+
+    colours: ["#d6654d", "#cdcdcd", "#812b2c", "#f2e11f", "#50545a"],
+
+    modes: [
+        {
+            id: "sky-kits",
+            type: Game_Variant_Type.Regular,
+            name: "Kits Solos",
+            team_size: 1,
+            team_amount: 12,
+            limited: false,
+            queue_type: Game_Variant_Queue_Type.Default,
+        },
+        {
+            id: "sky-kits-duos",
+            type: Game_Variant_Type.Duos,
+            name: "Kits Duos",
+            team_size: 2,
+            team_amount: 6,
+            limited: false,
+            queue_type: Game_Variant_Queue_Type.Default,
+        },
+    ],
+} as Game_Data<Game.SkywarsKits>;

--- a/src/types/api/api.types.ts
+++ b/src/types/api/api.types.ts
@@ -44,7 +44,7 @@ interface AllLeaderboards<T extends Timeframe> {
     [Game.MurderMystery]: API.MurderLeaderboard<T>;
     [Game.Skywars]: API.SkyLeaderboard<T>;
     [Game.SkywarsKits]: never;
-    [Game.SkywarsClassic]: never
+    [Game.SkywarsClassic]: never;
     [Game.SurvivalGames]: API.SgLeaderboard<T>;
     [Game.TheBridge]: API.BridgeLeaderboard<T>;
     [Game.TreasureWars]: API.WarsLeaderboard<T>;

--- a/src/types/api/api.types.ts
+++ b/src/types/api/api.types.ts
@@ -21,6 +21,8 @@ interface AllStatistics<T extends Timeframe> {
     [Game.JustBuild]: API.BuildStatistics<T>;
     [Game.MurderMystery]: API.MurderStatistics<T>;
     [Game.Skywars]: API.SkyStatistics<T>;
+    [Game.SkywarsKits]: API.SkyKitsStatistics<T>;
+    [Game.SkywarsClassic]: API.SkyClassicStatistics<T>;
     [Game.SurvivalGames]: API.SgStatistics<T>;
     [Game.TheBridge]: API.BridgeStatistics<T>;
     [Game.TreasureWars]: API.WarsStatistics<T>;
@@ -41,6 +43,8 @@ interface AllLeaderboards<T extends Timeframe> {
     [Game.JustBuild]: API.BuildLeaderboard<T>;
     [Game.MurderMystery]: API.MurderLeaderboard<T>;
     [Game.Skywars]: API.SkyLeaderboard<T>;
+    [Game.SkywarsKits]: never;
+    [Game.SkywarsClassic]: never
     [Game.SurvivalGames]: API.SgLeaderboard<T>;
     [Game.TheBridge]: API.BridgeLeaderboard<T>;
     [Game.TreasureWars]: API.WarsLeaderboard<T>;

--- a/src/types/api/games/index.types.ts
+++ b/src/types/api/games/index.types.ts
@@ -10,6 +10,8 @@ import { MurderStatistics, MurderLeaderboard } from "./murder.types";
 import { PartyStatistics, PartyLeaderboard } from "./party.types";
 import { SgStatistics, SgLeaderboard } from "./sg.types";
 import { SkyStatistics, SkyLeaderboard } from "./sky.types";
+import { SkyKitsStatistics } from "./sky-kits.types";
+import { SkyClassicStatistics } from "./sky-classic.types";
 import { WarsStatistics, WarsLeaderboard } from "./wars.types";
 import { BedStatistics, BedLeaderboard } from "./bed.types";
 import { ParkourStatistics } from "./parkour.types";
@@ -39,6 +41,8 @@ export {
     SgLeaderboard,
     SkyStatistics,
     SkyLeaderboard,
+    SkyKitsStatistics,
+    SkyClassicStatistics,
     WarsStatistics,
     WarsLeaderboard,
     BedStatistics,

--- a/src/types/api/games/sky-classic.types.ts
+++ b/src/types/api/games/sky-classic.types.ts
@@ -1,0 +1,20 @@
+import { Timeframe } from "../../enums";
+
+interface Statistics_SKY_CLASSIC {
+    xp: number;
+    played: number;
+    victories: number;
+    kills: number;
+    deaths: number;
+    selected_kit: string;
+}
+
+interface Statistics_SKY_CLASSIC_AllTime extends Statistics_SKY_CLASSIC {
+    UUID: string;
+}
+
+interface StatisticVariants {
+    [Timeframe.AllTime]: Statistics_SKY_CLASSIC_AllTime;
+    [Timeframe.Monthly]: never;
+}
+export type SkyClassicStatistics<T extends Timeframe> = StatisticVariants[T];

--- a/src/types/api/games/sky-kits.types.ts
+++ b/src/types/api/games/sky-kits.types.ts
@@ -1,0 +1,23 @@
+import { Timeframe } from "../../enums";
+
+interface Statistics_SKY_KITS {
+    xp: number;
+    played: number;
+    victories: number;
+    kills: number;
+    deaths: number;
+    mystery_chests_destroyed: number;
+    ores_mined: number;
+    spells_used: number;
+    selected_kit: string;
+}
+
+interface Statistics_SKY_KITS_AllTime extends Statistics_SKY_KITS {
+    UUID: string;
+}
+
+interface StatisticVariants {
+    [Timeframe.AllTime]: Statistics_SKY_KITS_AllTime;
+    [Timeframe.Monthly]: never;
+}
+export type SkyKitsStatistics<T extends Timeframe> = StatisticVariants[T];

--- a/src/types/games.types.ts
+++ b/src/types/games.types.ts
@@ -5,6 +5,8 @@ export enum Game {
     MurderMystery = "murder",
     SurvivalGames = "sg",
     Skywars = "sky",
+    SkywarsKits = "sky-kits",
+    SkywarsClassic = "sky-classic",
     CaptureTheFlag = "ctf",
     BlockDrop = "drop",
     GroundWars = "ground",


### PR DESCRIPTION
Important - this separates out the SkyWars Kits entry from the `modes` section of SkyWars into its own game, and adds SkyWars Classic similarly. One thing to note is that these three gamemodes share the same XP.